### PR TITLE
prevent conflict with change tool in vehicle

### DIFF
--- a/src/creatorTools.lua
+++ b/src/creatorTools.lua
@@ -258,9 +258,9 @@ function CreatorTools:drawHelpButtons()
     else
         g_currentMission:addHelpButtonText(g_i18n:getText("CT_HIDE_HUD_HELP"), InputBinding.CT_HUD_TOGGLE, nil, GS_PRIO_HIGH);
     end
-    g_currentMission:addHelpButtonText(g_i18n:getText("input_CT_OPEN_PANEL"), InputBinding.CT_OPEN_PANEL, nil, GS_PRIO_HIGH);
     if g_currentMission.controlledVehicle == nil then
         -- show only onfoot button helps
+        g_currentMission:addHelpButtonText(g_i18n:getText("input_CT_OPEN_PANEL"), InputBinding.CT_OPEN_PANEL, nil, GS_PRIO_NORMAL);
         --g_currentMission:addHelpButtonText(g_i18n:getText("AXIS_CT_FOVY_HELP"), InputBinding.AXIS_CT_FOVY, nil, GS_PRIO_LOW);
         --g_currentMission:addHelpButtonText(g_i18n:getText("input_CT_FOVY_DEFAULT"), InputBinding.CT_FOVY_DEFAULT, nil, GS_PRIO_LOW);
         --g_currentMission:addHelpButtonText(g_i18n:getText("AXIS_CT_CAMY_HELP"), InputBinding.AXIS_CT_CAMY, nil, GS_PRIO_LOW);


### PR DESCRIPTION
Show help for open creator control panel only when out of vehicle, to prevent conflict, and changed priority to normal, to avoid disappear help from other mod, like repair and so on.